### PR TITLE
Added CrowdSec scenario for banning people trying to scrape .env files

### DIFF
--- a/crowdsec/profiles.yaml
+++ b/crowdsec/profiles.yaml
@@ -7,6 +7,16 @@ decisions:
     duration: 48h
 on_success: break
 ---
+# Profile for banning anyone trying to access a .env file remotely. This is *never* legit.
+name: long_ban_for_env_attack
+filters:
+  - 'Alert.Remediation == true && Alert.GetScenario() == "custom/env-file-access"'
+decisions:
+  - type: ban
+    duration: 168h  # 7 days
+on_success: break
+
+---
 # Default profile (unchanged)
 name: default_ip_remediation
 #debug: true

--- a/crowdsec/scenarios/env-file-access.yaml
+++ b/crowdsec/scenarios/env-file-access.yaml
@@ -1,0 +1,18 @@
+name: custom/env-file-access
+description: "Very aggressively bans IPs trying to scrape .env files. This is never allowable."
+type: leaky
+author: jamie-alan-belanger
+filter: |
+  evt.Meta.log_type == 'http_access-log' &&
+  Lower(evt.Parsed.uri) matches '.*\\.env(\\.bak|\\.old|\\.backup|~|\\.txt)?$'
+groupby: evt.Parsed.remote_ip
+capacity: 1
+leakspeed: 168h  # One token every 7 days, effectively "once per week"
+blackhole: 1m
+labels:
+  type: exploit_attempt
+  remediation: true
+  classification:
+    - malicious-activity
+  behavior: scan
+

--- a/crowdsec/scenarios/well-known-probing.yaml
+++ b/crowdsec/scenarios/well-known-probing.yaml
@@ -1,7 +1,7 @@
 name: custom/well-known-probing
 description: "Aggressively bans IPs probing .well-known paths (except trusted ones)"
 type: leaky
-author: your-name
+author: jamie-alan-belanger
 filter: |
   evt.Meta.log_type == 'http_access-log' &&
   evt.Meta.http_status in ['404', '403', '400'] &&


### PR DESCRIPTION
Been seeing more and more people trying to scrape various `.env` files from my sites. Sometimes it's literally `.env`, and sometimes something like `twilio.env`. These files should never, ever be accessible outside the server. And they aren't, but still, even trying to query them is a security violation in my eyes. There are zero scenarios I can think of where such a request would ever be valid.

This new CrowdSec rule detects people trying to access any sort of `.env` variant _even once_ and bans their IP address for one week. Not that the regex will include variants like `.env.bak` or `.env.txt` too