### PR TITLE
Fixed issues with Traefik log formats

### DIFF
--- a/.env-default
+++ b/.env-default
@@ -29,7 +29,7 @@ CROWDSEC_CAPI_NAME=(whatever you want)
 
 ## Traefik plugin version (so you don't have to manually edit traefik-config.yml)
 ## Check https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
-BOUNCER_VERSION="v1.4.2"
+BOUNCER_VERSION="v1.4.4"
 
 ## Bouncer key for Traefik's local API
 ## Generate something like a GUID for this. It's used internally by Traefik

--- a/crowdsec/acquis.yaml
+++ b/crowdsec/acquis.yaml
@@ -1,5 +1,5 @@
 filenames:
-  - /var/log/traefik/*
+  - /var/log/traefik/*.log
 labels:
   type: traefik
 

--- a/crowdsec/scenarios/env-file-access.yaml
+++ b/crowdsec/scenarios/env-file-access.yaml
@@ -4,7 +4,7 @@ type: leaky
 author: jamie-alan-belanger
 filter: |
   evt.Meta.log_type == 'http_access-log' &&
-  Lower(evt.Parsed.uri) matches '.*\\.env(\\.bak|\\.old|\\.backup|~|\\.txt)?$'
+  Lower(evt.Meta.http_path) matches '.*\\.env(\\.bak|\\.old|\\.backup|~|\\.txt)?$'
 groupby: evt.Parsed.remote_ip
 capacity: 1
 leakspeed: 168h  # One token every 7 days, effectively "once per week"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,9 @@ services:
     command:
       - "--log"
       - "--log.filePath=/logs/traefik.log"
+      - "--log.format=json"
       - "--accessLog.filePath=/logs/access.log"
+      - "--accessLog.format=json"
       - "--accessLog.bufferingSize=100"
       - "--accessLog.fields.headers.defaultMode=keep"
 


### PR DESCRIPTION
A recent container update broke the custom scenarios. I switched Traefik to output JSON logs and updated the .env file access scenario.